### PR TITLE
fix: use uint64_t accumulator to prevent 49.7-day overflow in publish()

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -12,7 +12,15 @@ New features:
 
 Fixes:
 
-* ...
+* fix spurious "Local alarm" after ~49.7 days of uptime: the
+  ``accumulated_time`` counter used by the running average in
+  ``publish`` was a 32-bit ``unsigned long`` in milliseconds and
+  wrapped at 2^32 ms, which caused ``accumulated_Count_Rate`` and
+  ``accumulated_Dose_Rate`` to spike to huge values and trip the local
+  alarm every heartbeat thereafter. Accumulator is now ``uint64_t``
+  (~584 million year range). The serial log ``Accu_Time`` column is
+  now reported in seconds (``unsigned long``) instead of truncated
+  milliseconds, so it no longer goes negative after ~24 days either.
 
 Other changes:
 

--- a/multigeiger/log_data.cpp
+++ b/multigeiger/log_data.cpp
@@ -10,7 +10,7 @@ static const char *Serial_Logging_Name = "Simple Multi-Geiger";
 static const char *dashes = "------------------------------------------------------------------------------------------------------------------------";
 
 static const char *Serial_Logging_Header = "     %10s %15s %10s %9s %9s %8s %9s %9s %9s %5s %5s %6s";
-static const char *Serial_Logging_Body = "DATA %10d %15d %10f %9f %9d %8d %9d %9f %9f %5.1f %5.1f %6.0f";
+static const char *Serial_Logging_Body = "DATA %10d %15d %10f %9f %9d %8d %9lu %9f %9f %5.1f %5.1f %6.0f";
 static const char *Serial_One_Minute_Log_Header = "     %4s %10s %29s";
 static const char *Serial_One_Minute_Log_Body = "DATA %4d %10d %29d";
 
@@ -27,19 +27,19 @@ void setup_log_data(int mode) {
 }
 
 void log_data(int GMC_counts, int time_difference, float Count_Rate, float Dose_Rate, int HV_pulse_count,
-              int accumulated_GMC_counts, int accumulated_time, float accumulated_Count_Rate, float accumulated_Dose_Rate,
+              int accumulated_GMC_counts, unsigned long accumulated_time_s, float accumulated_Count_Rate, float accumulated_Dose_Rate,
               float t, float h, float p) {
   static int counter = 0;
   if (counter++ % 20 == 0) {  // output the header now and then, so table is better readable
     log(INFO, Serial_Logging_Header,
         "GMC_counts", "Time_difference", "Count_Rate", "Dose_Rate", "HV Pulses", "Accu_GMC", "Accu_Time", "Accu_Rate", "Accu_Dose", "Temp", "Humi", "Press");
     log(INFO, Serial_Logging_Header,
-        "[Counts]",   "[ms]",            "[cps]",      "[uSv/h]",   "[-]",       "[Counts]", "[ms]",      "[cps]",     "[uSv/h]",   "[C]",  "[%]",  "[hPa]");
+        "[Counts]",   "[ms]",            "[cps]",      "[uSv/h]",   "[-]",       "[Counts]", "[s]",       "[cps]",     "[uSv/h]",   "[C]",  "[%]",  "[hPa]");
     log(INFO, dashes);
   }
   log(INFO, Serial_Logging_Body,
       GMC_counts, time_difference, Count_Rate, Dose_Rate, HV_pulse_count,
-      accumulated_GMC_counts, accumulated_time, accumulated_Count_Rate, accumulated_Dose_Rate,
+      accumulated_GMC_counts, accumulated_time_s, accumulated_Count_Rate, accumulated_Dose_Rate,
       t, h, p);
 }
 

--- a/multigeiger/log_data.h
+++ b/multigeiger/log_data.h
@@ -14,7 +14,7 @@ extern int Serial_Print_Mode;
 
 void setup_log_data(int mode);
 void log_data(int GMC_counts, int time_difference, float Count_Rate, float Dose_Rate, int HV_pulse_count,
-              int accumulated_GMC_counts, int accumulated_time, float accumulated_Count_Rate, float accumulated_Dose_Rate,
+              int accumulated_GMC_counts, unsigned long accumulated_time_s, float accumulated_Count_Rate, float accumulated_Dose_Rate,
               float t, float h, float p);
 void log_data_one_minute(int time_s, int cpm, int counts);
 void log_data_statistics(int count_time_between);

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -113,7 +113,9 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
   static unsigned long last_hv_pulses = 0;
   static unsigned long last_count_timestamp = 0;
   static unsigned int accumulated_GMC_counts = 0;
-  static unsigned long accumulated_time = 0;
+  // 64-bit so this doesn't wrap at 2^32 ms (~49.7 d uptime) and cause a huge
+  // bogus accumulated_Count_Rate / accumulated_Dose_Rate -> spurious local alarm.
+  static uint64_t accumulated_time = 0;
   static float accumulated_Count_Rate = 0.0, accumulated_Dose_Rate = 0.0;
 
   if (((current_counts - last_counts) >= MINCOUNTS) || ((current_ms - last_timestamp) >= DISPLAYREFRESH)) {
@@ -161,7 +163,7 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
 
     if (Serial_Print_Mode == Serial_Logging) {
       log_data(counts, dt, Count_Rate, Dose_Rate, hv_pulses,
-               accumulated_GMC_counts, accumulated_time, accumulated_Count_Rate, accumulated_Dose_Rate,
+               accumulated_GMC_counts, (unsigned long)(accumulated_time / 1000), accumulated_Count_Rate, accumulated_Dose_Rate,
                temperature, humidity, pressure);
     }
   } else {


### PR DESCRIPTION
After ~49.7 days of uptime (2^32 ms) the accumulated_time counter in publish() wrapped around as a 32-bit unsigned long. The running averages accumulated_Count_Rate and accumulated_Dose_Rate are computed as accumulated_GMC_counts * 1000 / accumulated_time; once accumulated_time wraps back to a tiny value, the dose rate jumps to a huge number and soundLocalAlarm trips a spurious "Local alarm" at every heartbeat afterwards (observed on a long-running device).

Fix:
- Promote accumulated_time in publish() to uint64_t (~584M years range).
- log_data() now takes unsigned long accumulated_time_s (seconds) instead of an int in milliseconds. The caller passes accumulated_time / 1000. This also fixes the serial Accu_Time column going negative after ~24.8 days (2^31 ms as signed int).
- Update Serial_Logging_Body format specifier %9d -> %9lu and the units header "[ms]" -> "[s]" for the Accu_Time column.
- Add changelog entry under V1.17.0-dev.

Made-with: Cursor